### PR TITLE
Fixes issue #13 - Javadoc compilation errors

### DIFF
--- a/src/main/javr/core/AVR.java
+++ b/src/main/javr/core/AVR.java
@@ -126,7 +126,6 @@ public class AVR {
 		 * Poke a data byte into the contents of a given address.
 		 *
 		 * @param address
-		 * @return
 		 */
 		public void poke(int address, byte data);
 

--- a/src/main/javr/core/AvrInstruction.java
+++ b/src/main/javr/core/AvrInstruction.java
@@ -425,7 +425,7 @@ public abstract class AvrInstruction {
 		 * Turn a given format string into a 16-bit mask which identifies all fixed
 		 * bits.
 		 *
-		 * @param format
+		 * @param opcode
 		 * @return
 		 */
 		public int toMask(Opcode opcode) {

--- a/src/main/javr/core/Wire.java
+++ b/src/main/javr/core/Wire.java
@@ -19,7 +19,6 @@ public interface Wire {
 	/**
 	 * Read current state of pin.
 	 *
-	 * @param i
 	 * @return
 	 */
 	public boolean read();
@@ -27,7 +26,6 @@ public interface Wire {
 	/**
 	 * Write current state of pin.
 	 *
-	 * @param i
 	 * @return
 	 */
 	public boolean write(boolean value);

--- a/src/main/javr/util/AbstractSerialPeripheral.java
+++ b/src/main/javr/util/AbstractSerialPeripheral.java
@@ -131,7 +131,6 @@ public abstract class AbstractSerialPeripheral implements AvrPeripheral {
 	/**
 	 * Write next boolean from the internal buffer
 	 *
-	 * @return
 	 */
 	private void write(boolean b) {
 		int offset = (position / 8);

--- a/src/main/javr/util/generators/DecoderGenerator.java
+++ b/src/main/javr/util/generators/DecoderGenerator.java
@@ -212,7 +212,6 @@ public class DecoderGenerator {
 	 * Recursively split a given set of opcodes into a tree of groups.
 	 *
 	 * @param opcodes
-	 * @param mask
 	 * @return
 	 */
 	public static Group split(Set<Opcode> opcodes) {

--- a/src/tests/javr/tests/AvrEncodingTests.java
+++ b/src/tests/javr/tests/AvrEncodingTests.java
@@ -69,7 +69,7 @@ public class AvrEncodingTests {
 	 * expectation is that compilation should fail with an error and, hence, the
 	 * test fails if compilation does not.
 	 *
-	 * @param name
+	 * @param testName
 	 *            Name of the test to run. This must correspond to a whiley
 	 *            source file in the <code>WHILEY_SRC_DIR</code> directory.
 	 */
@@ -127,7 +127,7 @@ public class AvrEncodingTests {
 	 * Read a given hex file as a sequence of instructions. We can then encode these
 	 * back into binary data in order to check that the encoder works.
 	 *
-	 * @param filename
+	 * @param hf
 	 * @return
 	 * @throws IOException
 	 */


### PR DESCRIPTION
Fixes issues with incorrect parameters at [AvrInstruction.java:428](https://github.com/DavePearce/JavaAVR/blob/9dc510f3b16f9ec738c8e6594129afde4ba35069/src/main/javr/core/AvrInstruction.java#L428), [Wire.java:22](https://github.com/DavePearce/JavaAVR/blob/9dc510f3b16f9ec738c8e6594129afde4ba35069/src/main/javr/core/Wire.java#L22), [Wire.java:30](https://github.com/DavePearce/JavaAVR/blob/9dc510f3b16f9ec738c8e6594129afde4ba35069/src/main/javr/core/Wire.java#L30), [DecoderGenerator.java:215](https://github.com/DavePearce/JavaAVR/blob/9dc510f3b16f9ec738c8e6594129afde4ba35069/src/main/javr/util/generators/DecoderGenerator.java#L215), [AvrEncodingTests.java:72](https://github.com/DavePearce/JavaAVR/blob/9dc510f3b16f9ec738c8e6594129afde4ba35069/src/tests/javr/tests/AvrEncodingTests.java#L72), and [AvrEncodingTests.java:130](https://github.com/DavePearce/JavaAVR/blob/9dc510f3b16f9ec738c8e6594129afde4ba35069/src/tests/javr/tests/AvrEncodingTests.java#L130), as well as incorrect `@return` statements at [AVR.java:129](https://github.com/DavePearce/JavaAVR/blob/9dc510f3b16f9ec738c8e6594129afde4ba35069/src/main/javr/core/AVR.java#L129) and [AbstractSerialPeripheral.java:134](https://github.com/DavePearce/JavaAVR/blob/9dc510f3b16f9ec738c8e6594129afde4ba35069/src/main/javr/util/AbstractSerialPeripheral.java#L134).